### PR TITLE
libmuser: Organise lm_ctx_create and friends

### DIFF
--- a/lib/cap.c
+++ b/lib/cap.c
@@ -206,7 +206,7 @@ cap_is_valid(uint8_t id)
 }
 
 struct caps *
-caps_create(lm_cap_t *lm_caps, int nr_caps)
+caps_create(const lm_cap_t *lm_caps, int nr_caps)
 {
     uint8_t prev_end;
     int i, err = 0;

--- a/lib/cap.h
+++ b/lib/cap.h
@@ -44,7 +44,7 @@ struct caps;
  * capabilities have been added.
  */
 struct caps *
-caps_create(lm_cap_t *caps, int nr_caps);
+caps_create(const lm_cap_t *caps, int nr_caps);
 
 /*
  * Conditionally accesses the PCI capabilities. Returns:

--- a/lib/muser.h
+++ b/lib/muser.h
@@ -307,7 +307,7 @@ typedef struct {
  * @returns the lm_ctx to be used or NULL on error. Sets errno.
  */
 lm_ctx_t *
-lm_ctx_create(lm_dev_info_t *dev_info);
+lm_ctx_create(const lm_dev_info_t *dev_info);
 
 /**
  * Destroys libmuser context.


### PR DESCRIPTION
Current state of lm_ctx_create is quite messy. This cleans it up
considerably, moving the pci config space creation to a separate helper.
It gets rid of the 'extended' bool from dev_info, meaning that a client
that wants to have a 4KiB config header should specify it on the
corresponding region.

This may all need reviewing later if we decide that other regions may be
always handled by libmuser, in which case we can hide config, vga (and
maybe rom?) entirely from our clients.

Signed-off-by: Felipe Franciosi <felipe@nutanix.com>