### PR TITLE
Integrate with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: c
+dist: bionic
+compiler: gcc
+before_install:
+  - muser_dir=$(pwd)
+  - linux_dir=/tmp/linux
+  - mkdir "${linux_dir}"
+  - cd "${linux_dir}"
+  - git init
+  - git remote add origin git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+  - git fetch --depth 1 origin v5.2.21
+  - git checkout FETCH_HEAD
+  - patch -p1 < "${muser_dir}/patches/vfio.diff"
+  - make olddefconfig
+  - make prepare
+  - cd "${muser_dir}"
+script:
+  - KDIR=/tmp/linux make

--- a/lib/libmuser.c
+++ b/lib/libmuser.c
@@ -45,6 +45,7 @@
 #include <stddef.h>
 #include <sys/mman.h>
 #include <stdarg.h>
+#include <linux/vfio.h>
 
 #include "../kmod/muser.h"
 #include "muser.h"


### PR DESCRIPTION
This adds a simple .travis.yml file for integration with Travis CI. It
tries to build muser.git on a Ubuntu Bionic environment using the Linux
kernel 5.2.21.

Signed-off-by: Felipe Franciosi <felipe@nutanix.com>