### PR TITLE
support for huge pages

### DIFF
--- a/kmod/CMakeLists.txt
+++ b/kmod/CMakeLists.txt
@@ -33,7 +33,11 @@
 configure_file(muser.c ${CMAKE_CURRENT_BINARY_DIR}/muser.c COPYONLY)
 configure_file(muser.h ${CMAKE_CURRENT_BINARY_DIR}/muser.h COPYONLY)
 # FIXME need to pass "CFLAGS_muser.o := -DDEBUG" for debug builds
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/Kbuild "obj-m := muser.o")
+set(KMOD_MAKEFILE_CONTENT "obj-m := muser.o")
+IF(CMAKE_BUILD_TYPE MATCHES Debug)
+	set(KMOD_MAKEFILE_CONTENT "CFLAGS_muser.o := -DDEBUG\n${KMOD_MAKEFILE_CONTENT}")
+ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/Kbuild ${KMOD_MAKEFILE_CONTENT})
 
 # Build module using kernel's Makefile.
 set(KBUILD_CMD ${CMAKE_MAKE_PROGRAM} -C ${KDIR} M=${CMAKE_CURRENT_BINARY_DIR} modules)

--- a/kmod/muser.c
+++ b/kmod/muser.c
@@ -1279,9 +1279,9 @@ static int muser_mmap(struct mdev_device *const mdev,
 		err = mucmd.muser_cmd.err;
 	}
 	if (unlikely(err != 0)) {
-		muser_info("failed to mmap %#lx@%#lx: %d",
-		           mucmd.muser_cmd.mmap.request.len,
+		muser_info("failed to mmap %#lx-%#lx: %d",
 		           mucmd.muser_cmd.mmap.request.addr,
+		           mucmd.muser_cmd.mmap.request.addr + mucmd.muser_cmd.mmap.request.len,
 		           err);
 		return err;
 	}

--- a/kmod/muser.c
+++ b/kmod/muser.c
@@ -1019,7 +1019,7 @@ static ssize_t muser_read(struct mdev_device *mdev, char __user *buf,
 		_count = mucmd.muser_cmd.err;
 
 	if (_count < 0)
-		muser_dbg("failed to process read: %d, %d\n", err,
+		muser_dbg("failed to process read: %d, %d", err,
 		          mucmd.muser_cmd.err);
 
 	*ppos = mucmd.muser_cmd.rw.pos;
@@ -1206,7 +1206,7 @@ static int muser_ioctl_setup_cmd(struct mudev_cmd *mucmd, unsigned int cmd,
 	/* Pin pages of the calling context. */
 	err = pin_pages(mucmd, (char __user *)arg, argsz, 1);
 	if (unlikely(err)) {
-		muser_dbg("failed to pin pages: %d\n", err);
+		muser_dbg("failed to pin pages: %d", err);
 		return err;
 	}
 
@@ -1220,7 +1220,7 @@ static long muser_ioctl(struct mdev_device *mdev, unsigned int cmd,
 	struct mudev_cmd mucmd = { 0 };
 	int err;
 
-	muser_dbg("mdev=%p, cmd=%u, arg=0x%lX\n", mdev, cmd, arg);
+	muser_dbg("mdev=%p, cmd=%u, arg=0x%lX", mdev, cmd, arg);
 
 	if (cmd == VFIO_DEVICE_RESET) {
 		if (!device_trylock(mudev->dev))
@@ -1239,7 +1239,7 @@ static long muser_ioctl(struct mdev_device *mdev, unsigned int cmd,
 	/* Process mudev_cmd in server context. */
 	err = muser_process_cmd(mudev, &mucmd);
 	if (err != 0) {
-		muser_dbg("failed to process command: %d\n", err);
+		muser_dbg("failed to process command: %d", err);
 		err = -1;
 	}
 
@@ -1826,7 +1826,7 @@ static const struct file_operations libmuser_fops = {
 
 static void muser_device_release(struct device *dev)
 {
-	muser_info("muser dev released\n");
+	muser_info("muser dev released");
 }
 
 static char *muser_devnode(struct device *dev, umode_t *mode)

--- a/kmod/muser.c
+++ b/kmod/muser.c
@@ -472,7 +472,7 @@ static struct page *mudev_page_alloc(struct muser_dev *mudev,
 	struct page *pg;
 	int ret;
 
-	pg = alloc_page(GFP_KERNEL);
+	pg = alloc_page(GFP_HIGHUSER_MOVABLE | __GFP_ZERO);
 	if (unlikely(!pg))
 		return NULL;
 

--- a/kmod/muser.h
+++ b/kmod/muser.h
@@ -48,7 +48,10 @@ union muser_cmd_mmap {
 	struct {
 		unsigned long addr; /* iova for DMA_MAP, offset for MMAP */
 		unsigned long len;
+		unsigned long offset;
 		unsigned long flags;
+		struct file *file;
+		int fd;
 	} request;
 	unsigned long response;
 };

--- a/lib/libmuser.c
+++ b/lib/libmuser.c
@@ -543,8 +543,9 @@ muser_dma_unmap(lm_ctx_t *lm_ctx, struct muser_cmd *cmd)
 {
     int err;
 
-    lm_log(lm_ctx, LM_INF, "removing DMA region %#lx@%#lx\n",
-           cmd->mmap.request.len, cmd->mmap.request.addr);
+    lm_log(lm_ctx, LM_INF, "removing DMA region %#lx-%#lx\n",
+           cmd->mmap.request.addr,
+           cmd->mmap.request.addr + cmd->mmap.request.len);
 
     if (lm_ctx->dma == NULL) {
         lm_log(lm_ctx, LM_ERR, "DMA not initialized\n");
@@ -556,8 +557,10 @@ muser_dma_unmap(lm_ctx_t *lm_ctx, struct muser_cmd *cmd)
                                        cmd->mmap.request.len,
                                        lm_ctx->fd);
     if (err != 0) {
-        lm_log(lm_ctx, LM_ERR, "failed to remove DMA region %#lx@%#lx: %s\n",
-               cmd->mmap.request.len, cmd->mmap.request.addr, strerror(err));
+        lm_log(lm_ctx, LM_ERR, "failed to remove DMA region %#lx-%#lx: %s\n",
+               cmd->mmap.request.addr,
+               cmd->mmap.request.addr + cmd->mmap.request.len,
+               strerror(err));
     }
 
     return err;
@@ -568,8 +571,9 @@ muser_dma_map(lm_ctx_t *lm_ctx, struct muser_cmd *cmd)
 {
     int err;
 
-    lm_log(lm_ctx, LM_INF, "adding DMA region %#lx@%#lx\n",
-           cmd->mmap.request.len, cmd->mmap.request.addr);
+    lm_log(lm_ctx, LM_INF, "adding DMA region %#lx-%#lx\n",
+           cmd->mmap.request.addr,
+           cmd->mmap.request.addr + cmd->mmap.request.len);
 
     if (lm_ctx->dma == NULL) {
         lm_log(lm_ctx, LM_ERR, "DMA not initialized\n");
@@ -581,9 +585,9 @@ muser_dma_map(lm_ctx_t *lm_ctx, struct muser_cmd *cmd)
                                     cmd->mmap.request.len,
                                     lm_ctx->fd, 0);
     if (err < 0) {
-        lm_log(lm_ctx, LM_ERR, "failed to add DMA region %#lx@%#lx: %d\n",
-               cmd->mmap.request.len, cmd->mmap.request.addr, err);
-        return err;
+        lm_log(lm_ctx, LM_ERR, "failed to add DMA region %#lx-%#lx: %d\n",
+               cmd->mmap.request.addr,
+               cmd->mmap.request.addr + cmd->mmap.request.len, err);
     }
 
     return 0;
@@ -623,8 +627,8 @@ muser_mmap(lm_ctx_t *lm_ctx, struct muser_cmd *cmd)
 
 out:
     if (err != 0) {
-        lm_log(lm_ctx, LM_ERR, "failed to mmap device memory %#x@%#lx: %s\n",
-               len, offset, strerror(err));
+        lm_log(lm_ctx, LM_ERR, "failed to mmap device memory %#x-%#lx: %s\n",
+               offset, offset + len, strerror(err));
     }
 
     return -err;

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -30,6 +30,7 @@
 
 add_executable(test_read test_read.c)
 add_executable(test_mmap test_mmap.c)
+add_executable(test_dma_map test_dma_map.c)
 
 add_executable(gpio-pci-idio-16 gpio-pci-idio-16.c)
 target_link_libraries(gpio-pci-idio-16 muser)

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -34,6 +34,8 @@
 /* gpio-pci-idio-16 */
 
 #include <stdio.h>
+#include <err.h>
+#include <stdlib.h>
 
 #include "../lib/muser.h"
 
@@ -51,7 +53,11 @@ bar2_access(void *pvt, char * const buf, size_t count, loff_t offset,
 
 int main(int argc, char **argv)
 {
-    int err;
+    int ret;
+
+    if (argc != 2) {
+        err(EXIT_FAILURE, "missing MUSER device UUID");
+    }
 
     lm_dev_info_t dev_info = {
         .pci_info = {
@@ -66,11 +72,11 @@ int main(int argc, char **argv)
         .uuid = argv[1],
     };
 
-    err = lm_ctx_run(&dev_info);
-    if (err != 0) {
+    ret = lm_ctx_run(&dev_info);
+    if (ret != 0) {
         fprintf(stderr, "failed to realize device emulation: %m\n");
     }
-    return err;
+    return ret;
 }
 
 /* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/samples/test_dma_map.c
+++ b/samples/test_dma_map.c
@@ -1,0 +1,218 @@
+/*
+ * Userspace mediated device sample application
+ *
+ * Copyright (c) 2019, Nutanix Inc. All rights reserved.
+ *     Author: Thanos Makatos <thanos@nutanix.com>
+ *             Swapnil Ingle <swapnil.ingle@nutanix.com>
+ *             Felipe Franciosi <felipe@nutanix.com>
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *      * Redistributions of source code must retain the above copyright
+ *        notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *        notice, this list of conditions and the following disclaimer in the
+ *        documentation and/or other materials provided with the distribution.
+ *      * Neither the name of Nutanix nor the names of its contributors may be
+ *        used to endorse or promote products derived from this software without
+ *        specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ *  DAMAGE.
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <stdbool.h>
+#include <string.h>
+#include <linux/vfio.h>
+#include <limits.h>
+#include <assert.h>
+#include <sys/ioctl.h>
+#include <inttypes.h>
+#include <err.h>
+
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof(*array))
+
+#define VFIO_PATH           "/dev/vfio/"
+#define VFIO_CTR_PATH       VFIO_PATH "vfio"
+#define SYSFS_PCI_DEV_PATH  "/sys/bus/pci/devices/"
+#define SYSFS_IOMMU_GROUP   "/iommu_group"
+
+static int
+pci_group_id(const char *bdf)
+{
+	char *dev_path;
+	char group_path[PATH_MAX];
+	int group_id;
+
+	assert(bdf);
+
+	asprintf(&dev_path, SYSFS_PCI_DEV_PATH "%s" SYSFS_IOMMU_GROUP, bdf);
+	memset(group_path, 0, sizeof(group_path));
+	readlink(dev_path, group_path, sizeof(group_path));
+	free(dev_path);
+	sscanf(basename(group_path), "%d", &group_id);
+	return group_id;
+}
+
+static void*
+test_map_dma(const int fd, void *vaddr, unsigned long size, unsigned long iova,
+             bool huge)
+{
+	int err;
+	struct vfio_iommu_type1_dma_map dma_map = {
+		.argsz = sizeof(dma_map),
+		.flags = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE,
+		.vaddr = (unsigned long long)vaddr,
+		.iova = iova,
+		.size = size,
+	};
+	fprintf(stderr, "attempting to MAP_DMA IOVA=%llx\n", dma_map.iova);
+	
+	err = ioctl(fd, VFIO_IOMMU_MAP_DMA, &dma_map);
+	if (err) {
+		fprintf(stderr, "failed to MAP_DMA: %d (%s)\n", err,
+		        strerror(errno));
+		return NULL;
+	}
+
+	return (void*)dma_map.vaddr;
+}
+
+static void
+test_unmap_dma(const int fd, unsigned long size, unsigned long long iova)
+{
+	int err;
+	struct vfio_iommu_type1_dma_unmap dma_unmap = {
+		.argsz = sizeof dma_unmap,
+		.size = size,
+		.iova = iova,
+		.flags = 0
+	};
+
+	err = ioctl(fd, VFIO_IOMMU_UNMAP_DMA, &dma_unmap);
+	if (err) {
+		perror("UNMAP_DMA\n");
+		return;
+	}
+	printf("unmapped IOVA=%llx\n", dma_unmap.iova);
+}
+
+static int
+get_container_fd(const char *path)
+{
+	int err, vfio_ctr_fd, vfio_grp_fd, vfio_dev_fd;
+	char *grp_path;
+	struct vfio_iommu_type1_info iommu_info;
+
+	vfio_ctr_fd = open(VFIO_CTR_PATH, O_RDWR);
+	assert(vfio_ctr_fd >= 0);
+
+	// Open the VFIO entry for this device's IOMMU GROUP.
+	err = asprintf(&grp_path, VFIO_PATH "%d", pci_group_id(path));
+	assert(err > 0);
+	vfio_grp_fd = open(grp_path, O_RDWR);
+	assert(vfio_grp_fd >= 0);
+	free(grp_path);
+
+	// Add the group to the container.
+	err = ioctl(vfio_grp_fd, VFIO_GROUP_SET_CONTAINER, &vfio_ctr_fd);
+	assert(!err);
+
+	// Enable IOMMU type 1 on container.
+	err = ioctl(vfio_ctr_fd, VFIO_SET_IOMMU, VFIO_TYPE1v2_IOMMU);
+	assert(!err);
+
+	// Get a device fd from VFIO.
+	vfio_dev_fd = ioctl(vfio_grp_fd, VFIO_GROUP_GET_DEVICE_FD, path);
+	assert(vfio_dev_fd >= 0);
+
+	return vfio_ctr_fd;
+}
+
+int main(int argc, char * argv[])
+{
+	int vfio_ctr_fd;
+	void *dma_map_addr = NULL;
+	struct iovec dma_regions[] = {
+		{.iov_base = (void*)0x0, .iov_len = 1 << 21},
+		{.iov_base = (void*)(1 << 21), .iov_len = 1 << 21},
+	};
+	int i;
+	bool huge = true;
+	int fd;
+	int flags = MAP_SHARED;
+	void *vaddr;
+	size_t size = 1 << 23; /* FIXME */
+	int ret;
+
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s <MUSER device UUID>\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	vfio_ctr_fd = get_container_fd(argv[1]);
+
+	if (huge) {
+		char template[] = "/dev/hugepages/XXXXXX";
+		fd = mkstemp(template);
+		assert(fd != -1);
+	}
+
+	ret = lseek(fd, size, SEEK_END);
+	if (ret == -1) {
+		err(EXIT_FAILURE, "failed to seek at %d", size);
+	}
+
+	/*
+	 * Allocate some space and setup a DMA mapping.
+	 * It *must* be MAP_SHARED.
+	 */
+	vaddr = mmap(NULL, size, PROT_READ | PROT_WRITE, flags, fd, 0);
+	if (vaddr == MAP_FAILED) {
+		err(EXIT_FAILURE, "failed to mmap");
+	}
+
+	for (i = 0; i < ARRAY_SIZE(dma_regions); i++) {
+		if ((unsigned long long)dma_regions[i].iov_base + dma_regions[i].iov_len > size
+		    || (huge && (dma_regions[i].iov_len < (1 << 21)))) {
+			err(EXIT_FAILURE, "bad IOVA %#lx-%#lx\n",
+			    (unsigned long)dma_regions[i].iov_base,
+			    (unsigned long)dma_regions[i].iov_base + dma_regions[i].iov_len);
+		}
+		dma_map_addr = test_map_dma(vfio_ctr_fd, vaddr,
+		                            dma_regions[i].iov_len,
+		                            (unsigned long)dma_regions[i].iov_base,
+		                            huge);
+		if (!dma_map_addr)
+			exit(EXIT_FAILURE);
+	}
+
+	printf("press enter to continue\n");
+	getchar();
+
+	for (i = 0; i < ARRAY_SIZE(dma_regions); i++) {
+		test_unmap_dma(vfio_ctr_fd,
+		               (unsigned long long)dma_regions[i].iov_len,
+		               (unsigned long long)dma_regions[i].iov_base);
+	}
+	return 0;
+}


### PR DESCRIPTION
This PR fixes #29 by injecting the fd backing the VMA in the DMA registration and then requests libmuser to mmap this fd. Apart from allowing huge pages to work in muser, it also avoids having to pin guest pages.

Because we no longer call `vfio_pin_pages`, VFIO no longer sends us the DMA unregistration event, we need to fix this (the problem is that we get overlapping/duplicates DMA regions).

Also, we might be injecting multiple times the same fd, so we might want to optimize that.

This PR also includes some other minor improvements.