### PR TITLE
include region access header in response of region read/write command, plus assorted fixes

### DIFF
--- a/lib/libmuser.c
+++ b/lib/libmuser.c
@@ -208,7 +208,7 @@ init_sock(lm_ctx_t *lm_ctx)
 
     if ((unix_sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
 	    ret = errno;
-	    goto free_iommu_dir;
+        goto out;
     }
 
     if (lm_ctx->flags & LM_FLAG_ATTACH_NB) {
@@ -259,9 +259,7 @@ close_iommu_dir_fd:
     close(lm_ctx->iommu_dir_fd);
 close_unix_sock:
     close(unix_sock);
-free_iommu_dir:
-    free(lm_ctx->iommu_dir);
-
+out:
     return -ret;
 }
 

--- a/lib/libmuser.c
+++ b/lib/libmuser.c
@@ -194,16 +194,9 @@ init_sock(lm_ctx_t *lm_ctx)
 {
     struct sockaddr_un addr = { .sun_family = AF_UNIX };
     int ret, unix_sock;
-    unsigned long iommu_grp;
-    char *endptr;
     mode_t mode;
 
     assert(lm_ctx != NULL);
-
-    iommu_grp = strtoul(basename(lm_ctx->uuid), &endptr, 10);
-    if (*endptr != '\0' || (iommu_grp == ULONG_MAX && errno == ERANGE)) {
-        return -EINVAL;
-    }
 
     lm_ctx->iommu_dir = strdup(lm_ctx->uuid);
     if (!lm_ctx->iommu_dir) {

--- a/lib/vfio_user.h
+++ b/lib/vfio_user.h
@@ -38,58 +38,58 @@
 #include <linux/vfio.h>
 
 enum vfio_user_command {
-	VFIO_USER_VERSION			= 1,
-	VFIO_USER_DMA_MAP			= 2,
-	VFIO_USER_DMA_UNMAP			= 3,
-	VFIO_USER_DEVICE_GET_INFO		= 4,
-	VFIO_USER_DEVICE_GET_REGION_INFO	= 5,
-	VFIO_USER_DEVICE_GET_IRQ_INFO		= 6,
-	VFIO_USER_DEVICE_SET_IRQS		= 7,
-	VFIO_USER_REGION_READ			= 8,
-	VFIO_USER_REGION_WRITE			= 9,
-	VFIO_USER_DMA_READ			= 10,
-	VFIO_USER_DMA_WRITE			= 11,
-	VFIO_USER_VM_INTERRUPT			= 12,
-	VFIO_USER_DEVICE_RESET			= 13,
-	VFIO_USER_MAX,
+    VFIO_USER_VERSION                   = 1,
+    VFIO_USER_DMA_MAP                   = 2,
+    VFIO_USER_DMA_UNMAP                 = 3,
+    VFIO_USER_DEVICE_GET_INFO           = 4,
+    VFIO_USER_DEVICE_GET_REGION_INFO    = 5,
+    VFIO_USER_DEVICE_GET_IRQ_INFO       = 6,
+    VFIO_USER_DEVICE_SET_IRQS           = 7,
+    VFIO_USER_REGION_READ               = 8,
+    VFIO_USER_REGION_WRITE              = 9,
+    VFIO_USER_DMA_READ                  = 10,
+    VFIO_USER_DMA_WRITE                 = 11,
+    VFIO_USER_VM_INTERRUPT              = 12,
+    VFIO_USER_DEVICE_RESET              = 13,
+    VFIO_USER_MAX,
 };
 
 enum vfio_user_message_type {
-	VFIO_USER_MESSAGE_COMMAND		= 0,
-	VFIO_USER_MESSAGE_REPLY			= 1,
+    VFIO_USER_MESSAGE_COMMAND   = 0,
+    VFIO_USER_MESSAGE_REPLY     = 1,
 };
 
-#define VFIO_USER_FLAGS_NO_REPLY		(0x1)
+#define VFIO_USER_FLAGS_NO_REPLY    (0x1)
 
 struct vfio_user_header {
-	uint16_t	msg_id;
-	uint16_t	cmd;
-	uint32_t	msg_size;
-	struct {
-		uint32_t	type     : 4;
+    uint16_t    msg_id;
+    uint16_t    cmd;
+    uint32_t    msg_size;
+    struct {
+        uint32_t    type     : 4;
 #define VFIO_USER_F_TYPE_COMMAND    0
 #define VFIO_USER_F_TYPE_REPLY      1
-		uint32_t	no_reply : 1;
-		uint32_t	error    : 1;
-		uint32_t	resvd    : 26;
-	} flags;
-	uint32_t	error_no;
+        uint32_t    no_reply : 1;
+        uint32_t    error    : 1;
+        uint32_t    resvd    : 26;
+    } flags;
+    uint32_t    error_no;
 } __attribute__((packed));
 
 struct vfio_user_dma_region {
-	uint64_t	addr;
-	uint64_t	size;
-	uint64_t	offset;
-	uint32_t	prot;
-	uint32_t	flags;
-#define VFIO_USER_F_DMA_REGION_MAPPABLE	(0x0)
+    uint64_t    addr;
+    uint64_t    size;
+    uint64_t    offset;
+    uint32_t    prot;
+    uint32_t    flags;
+#define VFIO_USER_F_DMA_REGION_MAPPABLE (0x0)
 } __attribute__((packed));
 
 struct vfio_user_region_access {
-	uint64_t	offset;
-	uint32_t	region;
-	uint32_t	count;
-	uint8_t		data[];
+    uint64_t    offset;
+    uint32_t    region;
+    uint32_t    count;
+    uint8_t     data[];
 } __attribute__((packed));
 
 struct vfio_user_dma_region_access {

--- a/lib/vfio_user.h
+++ b/lib/vfio_user.h
@@ -103,3 +103,5 @@ struct vfio_user_irq_info {
 } __attribute__((packed));
 
 #endif
+
+/* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/samples/client.c
+++ b/samples/client.c
@@ -38,6 +38,7 @@
 #include <sys/eventfd.h>
 #include <time.h>
 #include <err.h>
+#include <assert.h>
 
 #include "../lib/muser.h"
 #include "../lib/muser_priv.h"
@@ -310,11 +311,12 @@ access_bar0(int sock)
 
     ret = send_recv_vfio_user_msg(sock, msg_id, VFIO_USER_REGION_READ,
                                   &data.region_access, sizeof data.region_access,
-                                  NULL, 0, NULL, &data.t, sizeof data.t);
+                                  NULL, 0, NULL, &data, sizeof data);
     if (ret < 0) {
         fprintf(stderr, "failed to read from BAR0: %s\n", strerror(-ret));
         return ret;
     }
+    assert(data.region_access.count == sizeof data.t);
 
     printf("read from BAR0: %ld\n", data.t);
 

--- a/samples/client.c
+++ b/samples/client.c
@@ -296,18 +296,22 @@ access_bar0(int sock)
         .t = time(NULL)
     };
     uint16_t msg_id = 1;
+    const int sleep_time = 1;
+    struct vfio_user_region_access region_access = {};
     int ret = send_recv_vfio_user_msg(sock, msg_id, VFIO_USER_REGION_WRITE,
-                                      &data, sizeof data, NULL, 0, NULL, NULL, 0);
+                                      &data, sizeof data, NULL, 0, NULL,
+                                      &region_access, sizeof region_access);
     if (ret < 0) {
         fprintf(stderr, "failed to write to BAR0: %s\n", strerror(-ret));
         return ret;
     }
+    assert(region_access.count == sizeof data.t);
 
     printf("wrote to BAR0: %ld\n", data.t);
 
-    sleep(2);
-
     msg_id++;
+
+    sleep(sleep_time);
 
     ret = send_recv_vfio_user_msg(sock, msg_id, VFIO_USER_REGION_READ,
                                   &data.region_access, sizeof data.region_access,
@@ -319,6 +323,8 @@ access_bar0(int sock)
     assert(data.region_access.count == sizeof data.t);
 
     printf("read from BAR0: %ld\n", data.t);
+
+    assert(data.t >= sleep_time);
 
     return 0;
 }

--- a/samples/client.c
+++ b/samples/client.c
@@ -542,6 +542,18 @@ int main(int argc, char *argv[])
     }
 
     /*
+     * XXX VFIO_USER_REGION_READ and VFIO_USER_REGION_WRITE
+     *
+     * BAR0 in the server does not support memory mapping so it must be accessed
+     * via explicit messages.
+     */
+    ret = access_bar0(sock);
+    if (ret < 0) {
+        fprintf(stderr, "failed to access BAR0: %s\n", strerror(-ret));
+        exit(EXIT_FAILURE);
+    }
+
+    /*
      * XXX VFIO_USER_DEVICE_GET_IRQ_INFO and VFIO_IRQ_SET_ACTION_TRIGGER
      * Query interrupts, configure an eventfd to be associated with INTx, and
      * finally wait for the server to fire the interrupt.
@@ -555,18 +567,6 @@ int main(int argc, char *argv[])
     ret = handle_dma_io(sock, dma_regions, nr_dma_regions, dma_region_fds);
     if (ret < 0) {
         fprintf(stderr, "DMA IO failed: %s\n", strerror(-ret));
-        exit(EXIT_FAILURE);
-    }
-
-    /*
-     * XXX VFIO_USER_REGION_READ and VFIO_USER_REGION_WRITE
-     *
-     * BAR0 in the server does not support memory mapping so it must be accessed
-     * via explicit messages.
-     */
-    ret = access_bar0(sock);
-    if (ret < 0) {
-        fprintf(stderr, "failed to access BAR0: %s\n", strerror(-ret));
         exit(EXIT_FAILURE);
     }
 

--- a/samples/server.c
+++ b/samples/server.c
@@ -264,7 +264,7 @@ int main(int argc, char *argv[])
 
     sigemptyset(&act.sa_mask);
     if (sigaction(SIGUSR1, &act, NULL) == -1) {
-        err(EXIT_FAILURE, "warning: failed to register signal handler: %m\n");
+        err(EXIT_FAILURE, "failed to register signal handler");
     }
 
     lm_ctx = lm_ctx_create(&dev_info);
@@ -272,7 +272,7 @@ int main(int argc, char *argv[])
         if (errno == EINTR) {
             goto out;
         }
-        err(EXIT_FAILURE, "failed to initialize device emulation: %m\n");
+        err(EXIT_FAILURE, "failed to initialize device emulation");
     }
 
     do {

--- a/samples/server.c
+++ b/samples/server.c
@@ -209,12 +209,14 @@ int main(int argc, char *argv[])
                 verbose = true;
                 break;
             default: /* '?' */
-                err(EXIT_FAILURE, "Usage: %s [-d] <IOMMU group>\n", argv[0]);
+                fprintf(stderr, "Usage: %s [-d] <IOMMU group>\n", argv[0]);
+                exit(EXIT_FAILURE);
         }
     }
 
     if (optind >= argc) {
-        err(EXIT_FAILURE, "missing MUSER device UUID");
+        fprintf(stderr, "missing MUSER device UUID\n");
+        exit(EXIT_FAILURE);
     }
 
     server_data.bar1 = malloc(sysconf(_SC_PAGESIZE));


### PR DESCRIPTION
The previous code was not implemented according to the spec as it didn't include the region access header in the response, neither the server sends it nor the client receives it. This patch fixes this erroneous behavior. Plus assorted fixes.

fixes #63 