### PR TITLE
eliminate duplicate recv(2) code

### DIFF
--- a/samples/client.c
+++ b/samples/client.c
@@ -229,6 +229,12 @@ static int get_device_info(int sock, struct vfio_device_info *dev_info)
         return ret;
     }
 
+    if (dev_info->num_regions != 10) {
+        fprintf(stderr, "bad number of device regions %d\n",
+                dev_info->num_regions);
+        return -EINVAL;
+    }
+
     printf("devinfo: flags %#x, num_regions %d, num_irqs %d\n",
            dev_info->flags, dev_info->num_regions, dev_info->num_irqs);
     return 0;


### PR DESCRIPTION
Instead of having each command handler do its own recv(2) to receive the
command, we do this once for all commands. This reduces the code a bit.

Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>