### PR TITLE
live migration: support for resuming in the destination server plus samples

### DIFF
--- a/lib/muser.h
+++ b/lib/muser.h
@@ -262,7 +262,7 @@ typedef int (lm_migration_callback_t)(void *pvt);
 
 typedef enum {
     LM_MIGR_STATE_STOP,
-    LM_MIGR_STATE_START,
+    LM_MIGR_STATE_RUNNING,
     LM_MIGR_STATE_STOP_AND_COPY,
     LM_MIGR_STATE_PRE_COPY,
     LM_MIGR_STATE_RESUME
@@ -303,10 +303,16 @@ typedef struct {
      */
     size_t (*read_data)(void *pvt, void *buf, __u64 count, __u64 offset);
 
-    /* Callback for restoring device state */
+    /* Callbacks for restoring device state */
+
+    /*
+     * Function that is called when client has written some previously stored
+     * device state.
+     */
+    int (*data_written)(void *pvt, __u64 count, __u64 offset);
 
     /* Fuction that is called for writing previously stored device state. */
-    size_t (*write_data)(void *pvt, void *data, __u64 size);
+    size_t (*write_data)(void *pvt, void *buf, __u64 count, __u64 offset);
 
 } lm_migration_callbacks_t;
 

--- a/lib/muser_ctx.c
+++ b/lib/muser_ctx.c
@@ -197,7 +197,8 @@ init_sock(lm_ctx_t *lm_ctx)
     /* start listening business */
     ret = bind(unix_sock, (struct sockaddr*)&addr, sizeof(addr));
     if (ret < 0) {
-	    ret = errno;
+        ret = -errno;
+        goto out;
     }
 
     ret = listen(unix_sock, 0);

--- a/lib/muser_priv.h
+++ b/lib/muser_priv.h
@@ -53,7 +53,7 @@ int
 _send_vfio_user_msg(int sock, uint16_t msg_id, bool is_reply,
                    enum vfio_user_command cmd,
                    struct iovec *iovecs, size_t nr_iovecs,
-                   int *fds, int count);
+                   int *fds, int count, int err);
 
 int
 send_vfio_user_msg(int sock, uint16_t msg_id, bool is_reply,

--- a/samples/client.c
+++ b/samples/client.c
@@ -39,7 +39,6 @@
 #include <time.h>
 #include <err.h>
 #include <assert.h>
-//#include <sys/uio.h>
 
 #include "../lib/muser.h"
 #include "../lib/muser_priv.h"

--- a/samples/client.c
+++ b/samples/client.c
@@ -905,6 +905,14 @@ int main(int argc, char *argv[])
        ret = migrate_from(sock);
     }
 
+    /*
+     * Try to touch BAR0, we should get an error as the device is stopped.
+     */
+    ret = access_bar0(sock);
+    if (ret != EINVAL) {
+        fprintf(stderr, "expected an error, got %d instead\n", ret);
+    }
+
     return 0;
 }
 

--- a/samples/client.c
+++ b/samples/client.c
@@ -130,11 +130,11 @@ get_region_vfio_caps(int sock, size_t cap_sz)
         switch (header->id) {
             case VFIO_REGION_INFO_CAP_SPARSE_MMAP:
                 sparse = (struct vfio_region_info_cap_sparse_mmap*)header;
-                fprintf(stdout, "%s: Sparse cap nr_mmap_areas %d\n", __func__,
-                        sparse->nr_areas);
+                printf("%s: Sparse cap nr_mmap_areas %d\n", __func__,
+                       sparse->nr_areas);
                 for (i = 0; i < sparse->nr_areas; i++) {
-                    fprintf(stdout, "%s: area %d offset %#llx size %llu\n", __func__,
-                            i, sparse->areas[i].offset, sparse->areas[i].size);
+                    printf("%s: area %d offset %#llx size %llu\n", __func__,
+                           i, sparse->areas[i].offset, sparse->areas[i].size);
                 }
                 break;
             case VFIO_REGION_INFO_CAP_TYPE:
@@ -183,9 +183,9 @@ get_device_region_info(int sock, struct vfio_device_info *client_dev_info)
         }
 
 	    cap_sz = region_info.argsz - sizeof(struct vfio_region_info);
-        fprintf(stdout, "%s: region_info[%d] offset %#llx flags %#x size %llu "
-                "cap_sz %lu\n", __func__, i, region_info.offset,
-                region_info.flags, region_info.size, cap_sz);
+        printf("%s: region_info[%d] offset %#llx flags %#x size %llu "
+               "cap_sz %lu\n", __func__, i, region_info.offset,
+               region_info.flags, region_info.size, cap_sz);
 	    if (cap_sz) {
             get_region_vfio_caps(sock, cap_sz);
 	    }


### PR DESCRIPTION
This patch implements support for resuming on the destination server while live migrating according to the VFIO live migration protocol. I've also extended the client/server sample to show how it's done, in a rather simplistic way.

The server is now a device that can be programmed to trigger an interrupt at a specific time. This is done by writing the desired seconds since Epoch to BAR0. We try to make the sample non-trivial by programming the device to trigger an interrupt after two seconds from now, immediately migrating to the new server, and then receiving the interrupt from the new server.

The client/server sample is started as usual. We don't create the destination client, the current one is reused (this would be done by libvirt, there's isn't much value in demonstrating how to do this anyway). However we do read the migration state from the source server and write it to the destination server. The destination server is started by the client (this would also be done by libvirt).

Some assorted fixes/improves are also included.