### PR TITLE
Api refactoring

### DIFF
--- a/include/muser.h
+++ b/include/muser.h
@@ -180,21 +180,6 @@ typedef struct {
      * unsupported regions should be left to 0.
      */
     lm_reg_info_t       reg_info[LM_DEV_NUM_REGS];
-
-    /*
-     * Device and vendor ID.
-     */
-    lm_pci_hdr_id_t     id;
-
-    /*
-     * Subsystem vendor and device ID.
-     */
-    lm_pci_hdr_ss_t     ss;
-
-    /*
-     * Class code.
-     */
-    lm_pci_hdr_cc_t     cc;
 } lm_pci_info_t;
 
 /*
@@ -397,6 +382,19 @@ typedef struct {
  */
 lm_ctx_t *
 lm_ctx_create(const lm_dev_info_t *dev_info);
+
+//TODO: Check other PCI header registers suitable to be filled by device.
+//      Or should we pass whole lm_pci_hdr_t to be filled by user.
+/**
+ * Setup PCI header data.
+ * @lm_ctx: the libmuser context
+ * @id: Device and vendor ID
+ * @ss: Subsystem vendor and device ID
+ * @cc: Class code
+ * @extended: support extented PCI config space
+ */
+int lm_setup_pci_hdr(lm_ctx_t *lm_ctx, lm_pci_hdr_id_t *id, lm_pci_hdr_ss_t *ss,
+                     lm_pci_hdr_cc_t *cc, bool extended);
 
 /**
  * Destroys libmuser context.

--- a/include/muser.h
+++ b/include/muser.h
@@ -381,10 +381,11 @@ enum {
 /**
  * Setup device IRQ counts.
  * @lm_ctx: the libmuser context
+ * @irq_idx: IRQ idx (LM_DEV_INTX_IRQ_IDX ... LM_DEV_REQ_IRQ_INDEX)
  * @irq_count: array of IRQ count value
  */
-int lm_setup_device_irq_counts(lm_ctx_t *lm_ctx,
-                               uint32_t irq_count[LM_DEV_NUM_IRQS]);
+int lm_setup_device_irq_counts(lm_ctx_t *lm_ctx, int irq_idx,
+                               uint32_t irq_count);
 
 //TODO: Re-visit once migration support is done.
 /**

--- a/include/muser.h
+++ b/include/muser.h
@@ -258,8 +258,6 @@ typedef struct {
      */
 #define LM_FLAG_ATTACH_NB  (1 << 0)
     uint64_t         flags;
-
-    lm_migration_t  migration;
 } lm_dev_info_t;
 
 /**
@@ -415,6 +413,14 @@ enum {
  */
 int lm_setup_device_irq_counts(lm_ctx_t *lm_ctx,
                                uint32_t irq_count[LM_DEV_NUM_IRQS]);
+
+//TODO: Re-visit once migration support is done.
+/**
+ * Enable support for device migration.
+ * @lm_ctx: the libmuser context
+ * @migration: information required to migrate device
+ */
+int lm_setup_device_migration(lm_ctx_t *lm_ctx, lm_migration_t *migration);
 
 /**
  * Destroys libmuser context.

--- a/include/muser.h
+++ b/include/muser.h
@@ -266,23 +266,6 @@ typedef struct {
      */
     lm_pci_info_t   pci_info;
 
-    /*
-     * Function that is called when the guest resets the device. Optional.
-     */
-    int (*reset)    (void *pvt);
-
-    /*
-     * Function that is called when the guest maps a DMA region. Optional.
-     */
-    void (*map_dma) (void *pvt, uint64_t iova, uint64_t len);
-
-    /*
-     * Function that is called when the guest unmaps a DMA region. The device
-     * must release all references to that region before the callback returns.
-     * This is required if you want to be able to access guest memory.
-     */
-    int (*unmap_dma) (void *pvt, uint64_t iova);
-
     lm_trans_t      trans;
 
     /*
@@ -349,7 +332,7 @@ int lm_setup_pci_caps(lm_ctx_t *lm_ctx, lm_cap_t **caps, int nr_caps);
  * @returns the number of bytes read or written, or a negative integer on error
  */
 typedef ssize_t (lm_region_access_cb_t) (void *pvt, char *buf, size_t count,
-                                      loff_t offset, bool is_write);
+                                         loff_t offset, bool is_write);
 
 typedef struct  {
 
@@ -406,6 +389,33 @@ int lm_setup_region(lm_ctx_t *lm_ctx, int region_idx, size_t size,
                     lm_region_access_cb_t *region_access, int flags,
                     struct lm_sparse_mmap_areas *mmap_areas,
                     lm_map_region_cb_t *map);
+
+/*
+ * Function that is called when the guest resets the device. Optional.
+ */
+typedef int (lm_reset_cb_t) (void *pvt);
+
+/*
+ * Function that is called when the guest maps a DMA region. Optional.
+ */
+typedef void (lm_map_dma_cb_t) (void *pvt, uint64_t iova, uint64_t len);
+
+/*
+ * Function that is called when the guest unmaps a DMA region. The device
+ * must release all references to that region before the callback returns.
+ * This is required if you want to be able to access guest memory.
+ */
+typedef int (lm_unmap_dma_cb_t) (void *pvt, uint64_t iova);
+
+/**
+ * Setup device callbacks.
+ * @lm_ctx: the libmuser context
+ * @reset: device reset callback
+ * @map_dma: DMA region map callback
+ * @unmap_dma: DMA region unmap callback
+ */
+int lm_setup_device_cb(lm_ctx_t *lm_ctx, lm_reset_cb_t *reset,
+                       lm_map_dma_cb_t *map_dma, lm_unmap_dma_cb_t *unmap_dma);
 
 /**
  * Destroys libmuser context.

--- a/include/muser.h
+++ b/include/muser.h
@@ -363,14 +363,7 @@ typedef struct {
 #define LM_FLAG_ATTACH_NB  (1 << 0)
     uint64_t         flags;
 
-    /*
-     * PCI capabilities.
-     */
-    int             nr_caps;
-    lm_cap_t        **caps;
-
     lm_migration_t  migration;
-
 } lm_dev_info_t;
 
 /**
@@ -395,6 +388,15 @@ lm_ctx_create(const lm_dev_info_t *dev_info);
  */
 int lm_setup_pci_hdr(lm_ctx_t *lm_ctx, lm_pci_hdr_id_t *id, lm_pci_hdr_ss_t *ss,
                      lm_pci_hdr_cc_t *cc, bool extended);
+
+//TODO: Support variable size capabilities.
+/**
+ * Setup PCI capabilities.
+ * @lm_ctx: the libmuser context
+ * @caps: array of (lm_cap_t *)
+ * *nr_caps: number of elements in @caps
+ */
+int lm_setup_pci_caps(lm_ctx_t *lm_ctx, lm_cap_t **caps, int nr_caps);
 
 /**
  * Destroys libmuser context.

--- a/include/muser.h
+++ b/include/muser.h
@@ -100,19 +100,6 @@ typedef unsigned long (lm_map_region_cb_t) (void *pvt, unsigned long off,
  */
 void *lm_mmap(lm_ctx_t * lm_ctx, off_t offset, size_t length);
 
-enum {
-    LM_DEV_INTX_IRQ_IDX,
-    LM_DEV_MSI_IRQ_IDX,
-    LM_DEV_MSIX_IRQ_IDX,
-    LM_DEV_ERR_IRQ_INDEX,
-    LM_DEV_REQ_IRQ_INDEX,
-    LM_DEV_NUM_IRQS
-};
-
-typedef struct {
-    uint32_t            irq_count[LM_DEV_NUM_IRQS];
-} lm_pci_info_t;
-
 /*
  * Returns a pointer to the standard part of the PCI configuration space.
  */
@@ -260,11 +247,6 @@ typedef struct {
      * Log level. Messages above this level are not logged. Optional
      */
     lm_log_lvl_t    log_lvl;
-
-    /*
-     * PCI configuration.
-     */
-    lm_pci_info_t   pci_info;
 
     lm_trans_t      trans;
 
@@ -416,6 +398,23 @@ typedef int (lm_unmap_dma_cb_t) (void *pvt, uint64_t iova);
  */
 int lm_setup_device_cb(lm_ctx_t *lm_ctx, lm_reset_cb_t *reset,
                        lm_map_dma_cb_t *map_dma, lm_unmap_dma_cb_t *unmap_dma);
+
+enum {
+    LM_DEV_INTX_IRQ_IDX,
+    LM_DEV_MSI_IRQ_IDX,
+    LM_DEV_MSIX_IRQ_IDX,
+    LM_DEV_ERR_IRQ_INDEX,
+    LM_DEV_REQ_IRQ_INDEX,
+    LM_DEV_NUM_IRQS
+};
+
+/**
+ * Setup device IRQ counts.
+ * @lm_ctx: the libmuser context
+ * @irq_count: array of IRQ count value
+ */
+int lm_setup_device_irq_counts(lm_ctx_t *lm_ctx,
+                               uint32_t irq_count[LM_DEV_NUM_IRQS]);
 
 /**
  * Destroys libmuser context.

--- a/include/muser.h
+++ b/include/muser.h
@@ -221,54 +221,26 @@ typedef struct {
     struct lm_sparse_mmap_areas *mmap_areas;
 } lm_migration_t;
 
-/**
- * Device information structure, used to create the lm_ctx.
- * To be filled and passed to lm_ctx_create()
+/*
+ * Attaching to the transport is non-blocking. The library will not attempt
+ * to attach during context creation time. The caller must then manually
+ * call lm_ctx_try_attach(), which is non-blocking, as many times as
+ * necessary.
  */
-typedef struct {
-    char            *uuid;
-
-    /*
-     * Private data passed to various lm_XXX functions.
-     */
-    void            *pvt;
-
-    /*
-     * Whether an extended PCI configuration space should be created.
-     */
-    bool            extended;
-
-    /*
-     * Function to call for logging. Optional.
-     */
-    lm_log_fn_t     *log;
-
-    /*
-     * Log level. Messages above this level are not logged. Optional
-     */
-    lm_log_lvl_t    log_lvl;
-
-    lm_trans_t      trans;
-
-    /*
-     * Attaching to the transport is non-blocking. The library will not attempt
-     * to attach during context creation time. The caller must then manually
-     * call lm_ctx_try_attach(), which is non-blocking, as many times as
-     * necessary.
-     */
 #define LM_FLAG_ATTACH_NB  (1 << 0)
-    uint64_t         flags;
-} lm_dev_info_t;
 
 /**
  * Creates libmuser context.
- *
- * @dev_info: device information used to create the context.
- *
+ * @path: path to socket file.
+ * @flags: context flag
+ * @log: log function
+ * @log_lvl: logging level
+ * @trans: transport type
+ * @pvt: private data
  * @returns the lm_ctx to be used or NULL on error. Sets errno.
  */
-lm_ctx_t *
-lm_ctx_create(const lm_dev_info_t *dev_info);
+lm_ctx_t *lm_create_ctx(const char *path, int flags, lm_log_fn_t *log,
+                        lm_log_lvl_t log_lvl, lm_trans_t trans, void *pvt);
 
 //TODO: Check other PCI header registers suitable to be filled by device.
 //      Or should we pass whole lm_pci_hdr_t to be filled by user.
@@ -440,16 +412,6 @@ lm_ctx_destroy(lm_ctx_t *lm_ctx);
  */
 int
 lm_ctx_drive(lm_ctx_t *lm_ctx);
-
-/**
- * Creates and runs an lm_ctx.
- *
- * @dev_info: device information used to create the context
- *
- * @returns 0 on success, -1 on failure. Sets errno.
- */
-int
-lm_ctx_run(lm_dev_info_t *dev_info);
 
 /**
  * Polls, without blocking, an lm_ctx. This is an alternative to using

--- a/lib/cap.h
+++ b/lib/cap.h
@@ -39,12 +39,9 @@ struct caps;
 
 /**
  * Initializes PCI capabilities.
- *
- * Returns <0 on error, 0 if no capabilities are to be added, and >0 if all
- * capabilities have been added.
  */
-struct caps *
-caps_create(lm_ctx_t *lm_ctx, lm_cap_t **caps, int nr_caps);
+struct caps *caps_create(lm_ctx_t *lm_ctx, lm_cap_t **caps, int nr_caps,
+                         int *err);
 
 /*
  * Conditionally accesses the PCI capabilities. Returns:

--- a/lib/dma.c
+++ b/lib/dma.c
@@ -150,7 +150,7 @@ dma_controller_remove_region(dma_controller_t *dma,
         region = &dma->regions[idx];
         if (region->dma_addr == dma_addr && region->size == size) {
             if (region->refcnt > 0) {
-                err = unmap_dma(data, region->dma_addr);
+                err = unmap_dma(data, region->dma_addr, region->size);
                 if (err != 0) {
                     lm_log(dma->lm_ctx, LM_ERR,
                            "failed to notify of removal of DMA region %#lx-%#lx: %s\n",

--- a/lib/dma.c
+++ b/lib/dma.c
@@ -138,7 +138,7 @@ dma_controller_region_valid(dma_controller_t *dma, dma_addr_t dma_addr,
 int
 dma_controller_remove_region(dma_controller_t *dma,
                              dma_addr_t dma_addr, size_t size,
-                             int (*unmap_dma) (void*, uint64_t), void *data)
+                             lm_unmap_dma_cb_t *unmap_dma, void *data)
 {
     int idx;
     dma_memory_region_t *region;

--- a/lib/dma.h
+++ b/lib/dma.h
@@ -73,6 +73,7 @@
 #include <sys/mman.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <limits.h>
 
 #include "muser.h"
 #include "common.h"

--- a/lib/dma.h
+++ b/lib/dma.h
@@ -120,7 +120,7 @@ dma_controller_add_region(dma_controller_t *dma,
 int
 dma_controller_remove_region(dma_controller_t *dma,
                              dma_addr_t dma_addr, size_t size,
-                             int (*unmap_dma) (void*, uint64_t), void *data);
+                             lm_unmap_dma_cb_t *unmap_dma, void *data);
 
 // Helper for dma_addr_to_sg() slow path.
 int

--- a/lib/migration.c
+++ b/lib/migration.c
@@ -75,18 +75,19 @@ static const __u32 migr_states[VFIO_DEVICE_STATE_MASK] = {
         (1 << VFIO_DEVICE_STATE_RESUMING)
 };
 
-struct migration*
-init_migration(const lm_migration_t * const lm_migr)
+struct migration *init_migration(const lm_migration_t * const lm_migr, int *err)
 {
     struct migration *migr;
 
+    *err = 0;
     if (lm_migr->size < sizeof(struct vfio_device_migration_info)) {
-        errno = EINVAL;
+        *err = EINVAL;
         return NULL;
     }
 
     migr = calloc(1, sizeof *migr);
     if (migr == NULL) {
+        *err = ENOMEM;
         return NULL;
     }
 
@@ -98,7 +99,7 @@ init_migration(const lm_migration_t * const lm_migr)
 
 
     /* FIXME this should be done in lm_ctx_run or poll */
-    migr->info.device_state = VFIO_DEVICE_STATE_RUNNING; 
+    migr->info.device_state = VFIO_DEVICE_STATE_RUNNING;
 
     migr->callbacks = lm_migr->callbacks;
     if (migr->callbacks.transition == NULL ||
@@ -107,9 +108,10 @@ init_migration(const lm_migration_t * const lm_migr)
         migr->callbacks.read_data == NULL ||
         migr->callbacks.write_data == NULL) {
         free(migr);
-        errno = EINVAL;
+        *err = EINVAL;
         return NULL;
     }
+
     return migr;
 }
 

--- a/lib/migration.h
+++ b/lib/migration.h
@@ -43,13 +43,12 @@
 
 #include "muser.h"
 
-struct migration *
-init_migration(const lm_migration_t * const lm_migr);
+struct migration *init_migration(const lm_migration_t * const lm_migr,
+                                 int *err);
 
 ssize_t
 handle_migration_region_access(lm_ctx_t *lm_ctx, void *pvt,
-                               struct migration *migr,
-                               char *buf, size_t count,
+                               struct migration *migr, char *buf, size_t count,
                                loff_t pos, bool is_write);
 
 bool

--- a/lib/muser_ctx.c
+++ b/lib/muser_ctx.c
@@ -565,7 +565,7 @@ handle_dma_map_or_unmap(lm_ctx_t *lm_ctx, uint32_t size, bool map,
                        dma_regions[i].addr,
                        dma_regions[i].addr + dma_regions[i].size - 1);
             }
-        } 
+        }
         if (ret < 0) {
             return ret;
         }
@@ -1227,7 +1227,6 @@ lm_ctx_create(const lm_dev_info_t *dev_info)
     lm_ctx->pvt = dev_info->pvt;
     lm_ctx->log = dev_info->log;
     lm_ctx->log_lvl = dev_info->log_lvl;
-    lm_ctx->reset = dev_info->reset;
     lm_ctx->flags = dev_info->flags;
 
     lm_ctx->uuid = strdup(dev_info->uuid);
@@ -1263,18 +1262,6 @@ lm_ctx_create(const lm_dev_info_t *dev_info)
         lm_ctx->fd = err;
     }
     err = 0;
-
-    lm_ctx->map_dma = dev_info->map_dma;
-    lm_ctx->unmap_dma = dev_info->unmap_dma;
-
-    // Create the internal DMA controller.
-    if (lm_ctx->unmap_dma != NULL) {
-        lm_ctx->dma = dma_controller_create(lm_ctx, LM_DMA_REGIONS);
-        if (lm_ctx->dma == NULL) {
-            err = errno;
-            goto out;
-        }
-    }
 
     // Attach to the muser control device. With LM_FLAG_ATTACH_NB caller is
     // always expected to call lm_ctx_try_attach().
@@ -1422,6 +1409,25 @@ int lm_setup_region(lm_ctx_t *lm_ctx, int region_idx, size_t size,
         }
     }
 #endif
+    return 0;
+}
+
+int lm_setup_device_cb(lm_ctx_t *lm_ctx, lm_reset_cb_t *reset,
+                       lm_map_dma_cb_t *map_dma, lm_unmap_dma_cb_t *unmap_dma)
+{
+
+    lm_ctx->reset = reset;
+    lm_ctx->map_dma = map_dma;
+    lm_ctx->unmap_dma = unmap_dma;
+
+    // Create the internal DMA controller.
+    if (lm_ctx->unmap_dma != NULL) {
+        lm_ctx->dma = dma_controller_create(lm_ctx, LM_DMA_REGIONS);
+        if (lm_ctx->dma == NULL) {
+            return ERROR(ENOMEM);
+        }
+    }
+
     return 0;
 }
 

--- a/lib/muser_ctx.c
+++ b/lib/muser_ctx.c
@@ -1149,11 +1149,6 @@ pci_config_setup(lm_ctx_t *lm_ctx, const lm_dev_info_t *dev_info)
         return -1;
     }
 
-    // Bounce misc PCI basic header data.
-    lm_ctx->pci_config_space->hdr.id = dev_info->pci_info.id;
-    lm_ctx->pci_config_space->hdr.cc = dev_info->pci_info.cc;
-    lm_ctx->pci_config_space->hdr.ss = dev_info->pci_info.ss;
-
     // Reflect on the config space whether INTX is available.
     if (dev_info->pci_info.irq_count[LM_DEV_INTX_IRQ_IDX] != 0) {
         lm_ctx->pci_config_space->hdr.intr.ipin = 1; // INTA#
@@ -1376,6 +1371,30 @@ out:
     }
 
     return lm_ctx;
+}
+
+static inline int ERROR(int err)
+{
+    errno = err;
+    return -1;
+}
+
+int lm_setup_pci_hdr(lm_ctx_t *lm_ctx, lm_pci_hdr_id_t *id, lm_pci_hdr_ss_t *ss,
+                     lm_pci_hdr_cc_t *cc, UNUSED bool extended)
+{
+    lm_pci_config_space_t *config_space = lm_ctx->pci_config_space;
+
+    if (id == NULL || ss == NULL || cc == NULL) {
+        return ERROR(EINVAL);
+    }
+
+    memcpy(&config_space->hdr.id, id, sizeof(lm_pci_hdr_id_t));
+    memcpy(&config_space->hdr.ss, ss, sizeof(lm_pci_hdr_ss_t));
+    memcpy(&config_space->hdr.cc, cc, sizeof(lm_pci_hdr_cc_t));
+
+    //TODO: supported extended PCI config space.
+
+    return 0;
 }
 
 /*

--- a/lib/muser_priv.h
+++ b/lib/muser_priv.h
@@ -95,6 +95,7 @@ struct lm_ctx {
 
     uint32_t                irq_count[LM_DEV_NUM_IRQS];
     lm_irqs_t               *irqs;
+    int                     ready;
 };
 
 int

--- a/lib/muser_priv.h
+++ b/lib/muser_priv.h
@@ -74,7 +74,6 @@ struct lm_ctx {
     lm_reset_cb_t           *reset;
     lm_log_lvl_t            log_lvl;
     lm_log_fn_t             *log;
-    uint32_t                irq_count[LM_DEV_NUM_IRQS];
     size_t                  nr_regions;
     lm_reg_info_t           *reg_info;
     lm_pci_config_space_t   *pci_config_space;
@@ -83,7 +82,7 @@ struct lm_ctx {
     uint64_t                flags;
     char                    *uuid;
     lm_map_dma_cb_t         *map_dma;
-    lm_unmap_dma_cb_t          *unmap_dma;
+    lm_unmap_dma_cb_t       *unmap_dma;
 
     /* TODO there should be a void * variable to store transport-specific stuff */
     /* LM_TRANS_SOCK */
@@ -94,7 +93,8 @@ struct lm_ctx {
     lm_reg_info_t           *migr_reg;
     struct migration        *migration;
 
-    lm_irqs_t               irqs; /* XXX must be last */
+    uint32_t                irq_count[LM_DEV_NUM_IRQS];
+    lm_irqs_t               *irqs;
 };
 
 int

--- a/lib/muser_priv.h
+++ b/lib/muser_priv.h
@@ -71,7 +71,7 @@ struct lm_ctx {
     dma_controller_t        *dma;
     int                     fd;
     int                     conn_fd;
-    int (*reset)            (void *pvt);
+    lm_reset_cb_t           *reset;
     lm_log_lvl_t            log_lvl;
     lm_log_fn_t             *log;
     uint32_t                irq_count[LM_DEV_NUM_IRQS];
@@ -82,8 +82,8 @@ struct lm_ctx {
     struct caps             *caps;
     uint64_t                flags;
     char                    *uuid;
-    void (*map_dma)         (void *pvt, uint64_t iova, uint64_t len);
-    int (*unmap_dma)        (void *pvt, uint64_t iova);
+    lm_map_dma_cb_t         *map_dma;
+    lm_unmap_dma_cb_t          *unmap_dma;
 
     /* TODO there should be a void * variable to store transport-specific stuff */
     /* LM_TRANS_SOCK */

--- a/lib/muser_priv.h
+++ b/lib/muser_priv.h
@@ -66,6 +66,33 @@ typedef struct {
 
 struct migration;
 
+typedef struct  {
+
+    /*
+     * Region flags, see LM_REG_FLAG_XXX above.
+     */
+    uint32_t            flags;
+
+    /*
+     * Size of the region.
+     */
+    uint32_t            size;
+
+    /*
+     * Callback function that is called when the region is read or written.
+     * Note that the memory of the region is owned by the user, except for the
+     * standard header (first 64 bytes) of the PCI configuration space.
+     */
+    lm_region_access_cb_t  *fn;
+
+    /*
+     * Callback function that is called when the region is memory mapped.
+     * Required if LM_REG_FLAG_MEM is set, otherwise ignored.
+     */
+    lm_map_region_cb_t     *map;
+    struct lm_sparse_mmap_areas *mmap_areas; /* sparse mmap areas */
+} lm_reg_info_t;
+
 struct lm_ctx {
     void                    *pvt;
     dma_controller_t        *dma;

--- a/samples/client.c
+++ b/samples/client.c
@@ -50,11 +50,11 @@
 #define CLIENT_MAX_FDS (32)
 
 static char *irq_to_str[] = {
-    [LM_DEV_INTX_IRQ_IDX] = "INTx",
-    [LM_DEV_MSI_IRQ_IDX] = "MSI",
-    [LM_DEV_MSIX_IRQ_IDX] = "MSI-X",
-    [LM_DEV_ERR_IRQ_INDEX] = "ERR",
-    [LM_DEV_REQ_IRQ_INDEX] = "REQ"
+    [LM_DEV_INTX_IRQ] = "INTx",
+    [LM_DEV_MSI_IRQ] = "MSI",
+    [LM_DEV_MSIX_IRQ] = "MSI-X",
+    [LM_DEV_ERR_IRQ] = "ERR",
+    [LM_DEV_REQ_IRQ] = "REQ"
 };
 
 void

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -94,19 +94,13 @@ main(int argc, char *argv[])
         errx(EXIT_FAILURE, "missing MUSER socket path");
     }
 
-    lm_dev_info_t dev_info = {
-        .trans = LM_TRANS_SOCK,
-        .log = verbose ? _log : NULL,
-        .log_lvl = LM_DBG,
-        .uuid = argv[optind],
-    };
-
     sigemptyset(&act.sa_mask);
     if (sigaction(SIGINT, &act, NULL) == -1) {
         err(EXIT_FAILURE, "failed to register signal handler");
     }
 
-    lm_ctx = lm_ctx_create(&dev_info);
+    lm_ctx = lm_create_ctx(argv[optind], 0, verbose ? _log : NULL, LM_DBG,
+                           LM_TRANS_SOCK, NULL);
     if (lm_ctx == NULL) {
         if (errno == EINTR) {
             printf("interrupted\n");

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -99,8 +99,8 @@ main(int argc, char *argv[])
         err(EXIT_FAILURE, "failed to register signal handler");
     }
 
-    lm_ctx = lm_create_ctx(argv[optind], 0, verbose ? _log : NULL, LM_DBG,
-                           LM_TRANS_SOCK, NULL);
+    lm_ctx = lm_create_ctx(LM_TRANS_SOCK, argv[optind], 0,
+                           verbose ? _log : NULL, LM_DBG, NULL);
     if (lm_ctx == NULL) {
         if (errno == EINTR) {
             printf("interrupted\n");
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
         err(EXIT_FAILURE, "failed to initialize device emulation");
     }
 
-    ret = lm_setup_pci_config_hdr(lm_ctx, id, ss, cc, false);
+    ret = lm_pci_setup_config_hdr(lm_ctx, id, ss, cc, false);
     if (ret < 0) {
         fprintf(stderr, "failed to setup pci header\n");
         goto out;

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -98,13 +98,6 @@ main(int argc, char *argv[])
         .trans = LM_TRANS_SOCK,
         .log = verbose ? _log : NULL,
         .log_lvl = LM_DBG,
-        .pci_info = {
-            .reg_info[LM_DEV_BAR2_REG_IDX] = {
-                .flags = LM_REG_FLAG_RW,
-                .size = 0x100,
-                .fn = &bar2_access
-            },
-        },
         .uuid = argv[optind],
     };
 
@@ -125,6 +118,13 @@ main(int argc, char *argv[])
     ret = lm_setup_pci_hdr(lm_ctx, &id, &ss, &cc, false);
     if (ret < 0) {
         fprintf(stderr, "failed to setup pci header\n");
+        goto out;
+    }
+
+    ret = lm_setup_region(lm_ctx, LM_DEV_BAR2_REG_IDX, 0x100, &bar2_access,
+                          LM_REG_FLAG_RW, NULL, NULL);
+    if (ret < 0) {
+        fprintf(stderr, "failed to setup region\n");
         goto out;
     }
 

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
         err(EXIT_FAILURE, "failed to initialize device emulation");
     }
 
-    ret = lm_setup_pci_hdr(lm_ctx, &id, &ss, &cc, false);
+    ret = lm_setup_pci_config_hdr(lm_ctx, id, ss, cc, false);
     if (ret < 0) {
         fprintf(stderr, "failed to setup pci header\n");
         goto out;

--- a/samples/null.c
+++ b/samples/null.c
@@ -78,9 +78,8 @@ int main(int argc, char **argv)
         errx(EXIT_FAILURE, "missing MUSER socket path");
     }
 
-    lm_dev_info_t dev_info = {.uuid = argv[1], .log = null_log, .log_lvl = LM_DBG };
-
-    lm_ctx_t *lm_ctx = lm_ctx_create(&dev_info);
+    lm_ctx_t *lm_ctx = lm_create_ctx(argv[1], 0, null_log, LM_DBG,
+                                     LM_TRANS_SOCK, NULL);
     if (lm_ctx == NULL) {
         err(EXIT_FAILURE, "failed to create libmuser context");
     }

--- a/samples/null.c
+++ b/samples/null.c
@@ -78,8 +78,8 @@ int main(int argc, char **argv)
         errx(EXIT_FAILURE, "missing MUSER socket path");
     }
 
-    lm_ctx_t *lm_ctx = lm_create_ctx(argv[1], 0, null_log, LM_DBG,
-                                     LM_TRANS_SOCK, NULL);
+    lm_ctx_t *lm_ctx = lm_create_ctx(LM_TRANS_SOCK, argv[1], 0, null_log,
+                                     LM_DBG, NULL);
     if (lm_ctx == NULL) {
         err(EXIT_FAILURE, "failed to create libmuser context");
     }

--- a/samples/server.c
+++ b/samples/server.c
@@ -385,7 +385,6 @@ int main(int argc, char *argv[])
     lm_pci_hdr_id_t id = {.raw = 0xdeadbeef};
     lm_pci_hdr_ss_t ss = {.raw = 0xcafebabe};
     lm_pci_hdr_cc_t cc = {.pi = 0xab, .scc = 0xcd, .bcc = 0xef};
-    uint32_t irq_count[LM_DEV_NUM_IRQS] = {0};
 
     while ((opt = getopt(argc, argv, "v")) != -1) {
         switch (opt) {
@@ -450,8 +449,7 @@ int main(int argc, char *argv[])
         errx(EXIT_FAILURE, "failed to setup device callbacks");
     }
 
-    irq_count[LM_DEV_INTX_IRQ_IDX] = 1;
-    ret = lm_setup_device_irq_counts(lm_ctx, irq_count);
+    ret = lm_setup_device_irq_counts(lm_ctx, LM_DEV_INTX_IRQ_IDX, 1);
     if (ret < 0) {
         errx(EXIT_FAILURE, "failed to setup irq counts");
     }

--- a/samples/server.c
+++ b/samples/server.c
@@ -427,31 +427,31 @@ int main(int argc, char *argv[])
         err(EXIT_FAILURE, "failed to initialize device emulation\n");
     }
 
-    ret = lm_setup_pci_hdr(lm_ctx, &id, &ss, &cc, false);
+    ret = lm_setup_pci_config_hdr(lm_ctx, id, ss, cc, false);
     if (ret < 0) {
-        errx(EXIT_FAILURE, "failed to setup PCI header");
+        err(EXIT_FAILURE, "failed to setup PCI header");
     }
 
     ret = lm_setup_region(lm_ctx, LM_DEV_BAR0_REG_IDX, sizeof(time_t),
                           &bar0_access, LM_REG_FLAG_RW, NULL, NULL);
     if (ret < 0) {
-        errx(EXIT_FAILURE, "failed to setup BAR0 region");
+        err(EXIT_FAILURE, "failed to setup BAR0 region");
     }
 
     ret = lm_setup_region(lm_ctx, LM_DEV_BAR1_REG_IDX, sysconf(_SC_PAGESIZE),
                           &bar1_access, LM_REG_FLAG_RW, sparse_areas, map_area);
     if (ret < 0) {
-        errx(EXIT_FAILURE, "failed to setup BAR1 region");
+        err(EXIT_FAILURE, "failed to setup BAR1 region");
     }
 
     ret = lm_setup_device_cb(lm_ctx, &device_reset, &map_dma, &unmap_dma);
     if (ret < 0) {
-        errx(EXIT_FAILURE, "failed to setup device callbacks");
+        err(EXIT_FAILURE, "failed to setup device callbacks");
     }
 
     ret = lm_setup_device_irq_counts(lm_ctx, LM_DEV_INTX_IRQ_IDX, 1);
     if (ret < 0) {
-        errx(EXIT_FAILURE, "failed to setup irq counts");
+        err(EXIT_FAILURE, "failed to setup irq counts");
     }
 
     lm_migration_t migration = {
@@ -469,13 +469,13 @@ int main(int argc, char *argv[])
 
     ret = lm_setup_device_migration(lm_ctx, &migration);
     if (ret < 0) {
-        errx(EXIT_FAILURE, "failed to setup device migration");
+        err(EXIT_FAILURE, "failed to setup device migration");
     }
 
     server_data.migration.migr_data = aligned_alloc(server_data.migration.migr_data_len,
                                                     server_data.migration.migr_data_len);
     if (server_data.migration.migr_data == NULL) {
-        errx(EXIT_FAILURE, "failed to allocate migration data");
+        err(EXIT_FAILURE, "failed to allocate migration data");
     }
 
     do {

--- a/samples/server.c
+++ b/samples/server.c
@@ -422,18 +422,6 @@ int main(int argc, char *argv[])
         .log = verbose ? _log : NULL,
         .log_lvl = LM_DBG,
         .pci_info = {
-            .reg_info[LM_DEV_BAR0_REG_IDX] = {
-                .flags = LM_REG_FLAG_RW,
-                .size = sizeof(time_t),
-                .fn = &bar0_access
-            },
-            .reg_info[LM_DEV_BAR1_REG_IDX] = {
-                .flags = LM_REG_FLAG_RW,
-                .size = sysconf(_SC_PAGESIZE),
-                .fn = &bar1_access,
-                .mmap_areas = sparse_areas,
-		        .map = map_area
-            },
             .irq_count[LM_DEV_INTX_IRQ_IDX] = 1,
         },
         .uuid = argv[optind],
@@ -468,6 +456,18 @@ int main(int argc, char *argv[])
     ret = lm_setup_pci_hdr(lm_ctx, &id, &ss, &cc, false);
     if (ret < 0) {
         errx(EXIT_FAILURE, "failed to setup PCI header");
+    }
+
+    ret = lm_setup_region(lm_ctx, LM_DEV_BAR0_REG_IDX, sizeof(time_t),
+                          &bar0_access, LM_REG_FLAG_RW, NULL, NULL);
+    if (ret < 0) {
+        errx(EXIT_FAILURE, "failed to setup BAR0 region");
+    }
+
+    ret = lm_setup_region(lm_ctx, LM_DEV_BAR1_REG_IDX, sysconf(_SC_PAGESIZE),
+                          &bar1_access, LM_REG_FLAG_RW, sparse_areas, map_area);
+    if (ret < 0) {
+        errx(EXIT_FAILURE, "failed to setup BAR1 region");
     }
 
     server_data.migration.migr_data = aligned_alloc(server_data.migration.migr_data_len,

--- a/samples/server.c
+++ b/samples/server.c
@@ -385,6 +385,7 @@ int main(int argc, char *argv[])
     lm_pci_hdr_id_t id = {.raw = 0xdeadbeef};
     lm_pci_hdr_ss_t ss = {.raw = 0xcafebabe};
     lm_pci_hdr_cc_t cc = {.pi = 0xab, .scc = 0xcd, .bcc = 0xef};
+    uint32_t irq_count[LM_DEV_NUM_IRQS] = {0};
 
     while ((opt = getopt(argc, argv, "v")) != -1) {
         switch (opt) {
@@ -421,9 +422,6 @@ int main(int argc, char *argv[])
         .trans = LM_TRANS_SOCK,
         .log = verbose ? _log : NULL,
         .log_lvl = LM_DBG,
-        .pci_info = {
-            .irq_count[LM_DEV_INTX_IRQ_IDX] = 1,
-        },
         .uuid = argv[optind],
         .pvt = &server_data,
         .migration = {
@@ -470,6 +468,12 @@ int main(int argc, char *argv[])
     ret = lm_setup_device_cb(lm_ctx, &device_reset, &map_dma, &unmap_dma);
     if (ret < 0) {
         errx(EXIT_FAILURE, "failed to setup device callbacks");
+    }
+
+    irq_count[LM_DEV_INTX_IRQ_IDX] = 1;
+    ret = lm_setup_device_irq_counts(lm_ctx, irq_count);
+    if (ret < 0) {
+        errx(EXIT_FAILURE, "failed to setup irq counts");
     }
 
     server_data.migration.migr_data = aligned_alloc(server_data.migration.migr_data_len,

--- a/samples/server.c
+++ b/samples/server.c
@@ -417,20 +417,13 @@ int main(int argc, char *argv[])
         sparse_areas->areas[i].start += size;
         sparse_areas->areas[i].size = size;
     }
-    lm_dev_info_t dev_info = {
-        .trans = LM_TRANS_SOCK,
-        .log = verbose ? _log : NULL,
-        .log_lvl = LM_DBG,
-        .uuid = argv[optind],
-        .pvt = &server_data,
-    };
-
     sigemptyset(&act.sa_mask);
     if (sigaction(SIGALRM, &act, NULL) == -1) {
         err(EXIT_FAILURE, "failed to register signal handler");
     }
 
-    server_data.lm_ctx = lm_ctx = lm_ctx_create(&dev_info);
+    server_data.lm_ctx = lm_ctx = lm_create_ctx(argv[optind], 0,
+            verbose ? _log : NULL, LM_DBG, LM_TRANS_SOCK, &server_data);
     if (lm_ctx == NULL) {
         err(EXIT_FAILURE, "failed to initialize device emulation\n");
     }

--- a/samples/server.c
+++ b/samples/server.c
@@ -382,6 +382,9 @@ int main(int argc, char *argv[])
     int nr_sparse_areas = 2, size = 1024, i;
     struct lm_sparse_mmap_areas *sparse_areas;
     lm_ctx_t *lm_ctx;
+    lm_pci_hdr_id_t id = {.raw = 0xdeadbeef};
+    lm_pci_hdr_ss_t ss = {.raw = 0xcafebabe};
+    lm_pci_hdr_cc_t cc = {.pi = 0xab, .scc = 0xcd, .bcc = 0xef};
 
     while ((opt = getopt(argc, argv, "v")) != -1) {
         switch (opt) {
@@ -419,9 +422,6 @@ int main(int argc, char *argv[])
         .log = verbose ? _log : NULL,
         .log_lvl = LM_DBG,
         .pci_info = {
-            .id.raw = 0xdeadbeef,
-            .ss.raw = 0xcafebabe,
-            .cc = {.pi = 0xab, .scc = 0xcd, .bcc = 0xef},
             .reg_info[LM_DEV_BAR0_REG_IDX] = {
                 .flags = LM_REG_FLAG_RW,
                 .size = sizeof(time_t),
@@ -463,6 +463,11 @@ int main(int argc, char *argv[])
     server_data.lm_ctx = lm_ctx = lm_ctx_create(&dev_info);
     if (lm_ctx == NULL) {
         err(EXIT_FAILURE, "failed to initialize device emulation\n");
+    }
+
+    ret = lm_setup_pci_hdr(lm_ctx, &id, &ss, &cc, false);
+    if (ret < 0) {
+        errx(EXIT_FAILURE, "failed to setup PCI header");
     }
 
     server_data.migration.migr_data = aligned_alloc(server_data.migration.migr_data_len,

--- a/samples/server.c
+++ b/samples/server.c
@@ -425,9 +425,6 @@ int main(int argc, char *argv[])
             .irq_count[LM_DEV_INTX_IRQ_IDX] = 1,
         },
         .uuid = argv[optind],
-        .reset = device_reset,
-        .map_dma = map_dma,
-        .unmap_dma = unmap_dma,
         .pvt = &server_data,
         .migration = {
             .size = server_data.migration.migr_data_len,
@@ -468,6 +465,11 @@ int main(int argc, char *argv[])
                           &bar1_access, LM_REG_FLAG_RW, sparse_areas, map_area);
     if (ret < 0) {
         errx(EXIT_FAILURE, "failed to setup BAR1 region");
+    }
+
+    ret = lm_setup_device_cb(lm_ctx, &device_reset, &map_dma, &unmap_dma);
+    if (ret < 0) {
+        errx(EXIT_FAILURE, "failed to setup device callbacks");
     }
 
     server_data.migration.migr_data = aligned_alloc(server_data.migration.migr_data_len,


### PR DESCRIPTION
Following are the proposed new API's
```
lm_ctx_t *lm_create_ctx(const char *path, int flags, lm_log_fn_t *log,
                        lm_log_lvl_t log_lvl, lm_trans_t trans, void *pvt);

int lm_setup_pci_hdr(lm_ctx_t *lm_ctx, lm_pci_hdr_id_t *id, lm_pci_hdr_ss_t *ss,
                     lm_pci_hdr_cc_t *cc, bool extended);

int lm_setup_pci_caps(lm_ctx_t *lm_ctx, lm_cap_t **caps, int nr_caps);

int lm_setup_region(lm_ctx_t *lm_ctx, int region_idx, size_t size,
                    lm_region_access_cb_t *region_access, int flags,
                    struct lm_sparse_mmap_areas *mmap_areas,
                    lm_map_region_cb_t *map);


int lm_setup_device_cb(lm_ctx_t *lm_ctx, lm_reset_cb_t *reset,
                       lm_map_dma_cb_t *map_dma, lm_unmap_dma_cb_t *unmap_dma);

int lm_setup_device_irq_counts(lm_ctx_t *lm_ctx, int irq_idx,
                               uint32_t irq_count);


int lm_setup_device_migration(lm_ctx_t *lm_ctx, lm_migration_t *migration);
```
There's still scope to add args validation and some TODO's. Those will be addressed later. I wanted to get this done first, as this touches most of the common code and clashes with other developments.
